### PR TITLE
Remove package relocation for jersey 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,16 +64,6 @@
                                     <exclude>junit:junit</exclude>
                                 </excludes>
                             </artifactSet>
-                            <relocations>
-                                <relocation>
-                                    <pattern>org.glassfish</pattern>
-                                    <shadedPattern>com.wavefront.jersey-sdk.org.glassfish</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.jvnet</pattern>
-                                    <shadedPattern>com.wavefront.jersey-sdk.org.jvnet</shadedPattern>
-                                </relocation>
-                            </relocations>
                             <filters>
                                 <filter>
                                     <excludes>


### PR DESCRIPTION
As it won't interoperate with the jersey version being used in an application.