### PR TITLE
Remove provided scope for jersey-server 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
             <version>2.25.1</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
as we expect user to dependency manage jersey.