### PR TITLE
Add client side filter for basic mode and inject jersey path into header

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,17 @@ In the code for each web service in your Jersey application:
 * Instantiate a `WavefrontJerseyFilter` object. Pass in the configuration files you created above.
     ```java
     // Instantiate the WavefrontJerseyFilter
-    WavefrontJerseyFilter wavefrontJerseyFilter =
-            YamlReader.constructJerseyFilter(applicationTagsYamlFile, wfReportingConfigYamlFile);
+    WavefrontJerseyFactory wavefrontJerseyFactory = new WavefrontJerseyFactory(
+        applicationTagsYamlFile, wfReportingConfigYamlFile);
+    WavefrontJerseyFilter wavefrontJerseyFilter = wavefrontJerseyFactory.getWavefrontJerseyFilter();
+    ```
+
+* *Optional*: You can also get [WavefrontJaxrsClientFilter](https://github.com/wavefrontHQ/wavefront-jaxrs-sdk-java) from the `WavefrontJerseyFactory` for instrumenting your JAX-RS-based client to form a complete trace.
+
+* ```java
+    // Instantiate the WavefrontJaxrsClientFilter
+    WavefrontJaxrsClientFilter wavefrontJaxrsClientFilter = wavefrontJerseyFactory.
+        getWavefrontJaxrsClientFilter();
     ```
 
 ### 4. Register the WavefrontJerseyFilter

--- a/docs/custom.md
+++ b/docs/custom.md
@@ -1,5 +1,5 @@
 # Wavefront Jersey SDK
-This page provides custom steps for setting up the Wavefront by VMware Jersey SDK in your application. With custom setup, you instantiate helper objects explicitly in your code instead of using the configuration files shown with [Quickstart setup](https://github.com/wavefrontHQ/wavefront-jersey-sdk-java/blob/master/README.html).
+This page provides custom steps for setting up the Wavefront by VMware Jersey SDK in your application. With custom setup, you instantiate helper objects explicitly in your code instead of using the configuration files shown with [Quickstart setup](https://github.com/wavefrontHQ/wavefront-jersey-sdk-java#quickstart).
 
 Custom setup gives you complete control over all settable aspects of instrumenting the Jersey framework in a microservice. You should use custom setup if you want to tune performance through the `WavefrontSender`, or if you want to implement your own configuration-file mechanism.  
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,18 @@
             <version>0.9.0</version>
         </dependency>
         <dependency>
+            <!--TODO: Remove once new version of wavefront-internal-reporter-java is released-->
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.9.6</version>
+        </dependency>
+        <dependency>
+            <!--TODO: Remove once new version of wavefront-internal-reporter-java is released-->
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.6</version>
+        </dependency>
+        <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-appagent-sdk-jvm</artifactId>
             <!-- TODO change from SNAPSHOT to v0.9.0 -->

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,7 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-internal-reporter-java</artifactId>
-            <!-- TODO change from SNAPSHOT to v0.9.0 -->
-            <version>0.9.0-SNAPSHOT</version>
+            <version>0.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.wavefront</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-jaxrs-sdk-java</artifactId>
+            <!-- TODO change from SNAPSHOT to v0.9.0 -->
             <version>0.9.0-SNAPSHOT</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
             <version>0.9.1</version>
         </dependency>
         <dependency>
+            <groupId>com.wavefront</groupId>
+            <artifactId>wavefront-jaxrs-sdk-java</artifactId>
+            <version>0.9.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
             <version>2.25.1</version>

--- a/src/main/java/com/wavefront/sdk/jersey/WavefrontJerseyFactory.java
+++ b/src/main/java/com/wavefront/sdk/jersey/WavefrontJerseyFactory.java
@@ -40,6 +40,10 @@ public class WavefrontJerseyFactory {
   private final WavefrontJerseyFilter wavefrontJerseyFilter;
   private final WavefrontJaxrsClientFilter wavefrontJaxrsClientFilter;
 
+  /**
+   * Construct WavefrontJerseyFactory with given yaml files path of application tags and Wavefront
+   * reporting configuration.
+   */
   public WavefrontJerseyFactory(String applicationTagsYamlFile, String wfReportingConfigYamlFile) {
 
     // Step 1 - Create an ApplicationTags instance, which specifies metadata about your application.

--- a/src/main/java/com/wavefront/sdk/jersey/WavefrontJerseyFactory.java
+++ b/src/main/java/com/wavefront/sdk/jersey/WavefrontJerseyFactory.java
@@ -4,15 +4,16 @@ import com.wavefront.config.WavefrontReportingConfig;
 import com.wavefront.opentracing.WavefrontTracer;
 import com.wavefront.opentracing.reporting.WavefrontSpanReporter;
 import com.wavefront.sdk.appagent.jvm.reporter.WavefrontJvmReporter;
-import com.wavefront.sdk.common.Pair;
 import com.wavefront.sdk.common.WavefrontSender;
 import com.wavefront.sdk.common.application.ApplicationTags;
-import com.wavefront.sdk.jaxrs.client.ClientTracingFilter;
+import com.wavefront.sdk.jaxrs.client.WavefrontJaxrsClientFilter;
 import com.wavefront.sdk.jersey.reporter.WavefrontJerseyReporter;
 
 import org.apache.commons.lang3.BooleanUtils;
 
 import java.io.IOException;
+
+import io.opentracing.Tracer;
 
 import static com.wavefront.config.ReportingUtils.constructApplicationTags;
 import static com.wavefront.config.ReportingUtils.constructWavefrontReportingConfig;
@@ -25,55 +26,101 @@ import static com.wavefront.config.ReportingUtils.constructWavefrontSender;
  *
  * @author Sushant Dewan (sushant@wavefront.com).
  */
-public abstract class YamlReader {
-  public static Pair<WavefrontJerseyFilter, ClientTracingFilter> constructJerseyFilter(
-      String applicationTagsYamlFile, String wfReportingConfigYamlFile) {
+public class WavefrontJerseyFactory {
+  private final ApplicationTags applicationTags;
+  private final String source;
+  private final Tracer tracer;
+  private final WavefrontSender wavefrontSender;
+  private final WavefrontJerseyReporter wfJerseyReporter;
+  private final WavefrontJvmReporter wfJvmReporter;
+  private final WavefrontJerseyFilter wavefrontJerseyFilter;
+  private final WavefrontJaxrsClientFilter wavefrontJaxrsClientFilter;
+
+  public WavefrontJerseyFactory(String applicationTagsYamlFile, String wfReportingConfigYamlFile) {
+
     // Step 1 - Create an ApplicationTags instance, which specifies metadata about your application.
-    ApplicationTags applicationTags = constructApplicationTags(applicationTagsYamlFile);
+    this.applicationTags = constructApplicationTags(applicationTagsYamlFile);
 
     // Step 2 - Construct WavefrontReportingConfig
     WavefrontReportingConfig wfReportingConfig =
         constructWavefrontReportingConfig(wfReportingConfigYamlFile);
 
+    this.source = wfReportingConfig.getSource();
+
     // Step 3 - Create a WavefrontSender for sending data to Wavefront.
-    WavefrontSender wavefrontSender = constructWavefrontSender(wfReportingConfig);
+    this.wavefrontSender = constructWavefrontSender(wfReportingConfig);
 
     // Step 4 - Create a WavefrontJerseyReporter for reporting
     // Jersey metrics and histograms to Wavefront.
-    WavefrontJerseyReporter wfJerseyReporter = new WavefrontJerseyReporter.Builder
-            (applicationTags).withSource(wfReportingConfig.getSource()).build(wavefrontSender);
+    this.wfJerseyReporter = new WavefrontJerseyReporter.Builder
+        (applicationTags).withSource(source).build(wavefrontSender);
 
     // Step 5 - Create a WavefrontJerseyFilter.Builder
     WavefrontJerseyFilter.Builder wfJerseyFilterBuilder = new WavefrontJerseyFilter.Builder
-            (wfJerseyReporter, applicationTags);
+        (wfJerseyReporter, applicationTags);
 
-    WavefrontTracer tracer = null;
     if (BooleanUtils.isTrue(wfReportingConfig.getReportTraces())) {
       // Step 6 - Optionally create a WavefrontTracer for reporting trace data
       // from Jersey APIs to Wavefront.
       WavefrontSpanReporter wfSpanReporter;
       try {
         wfSpanReporter = new WavefrontSpanReporter.Builder().
-            withSource(wfReportingConfig.getSource()).build(wavefrontSender);
+            withSource(source).build(wavefrontSender);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
       tracer = new WavefrontTracer.Builder(wfSpanReporter, applicationTags).build();
       wfJerseyFilterBuilder.withTracer(tracer);
+    } else {
+      tracer = null;
     }
 
     // Step 7 - Start the Jersey reporter to report metrics and histograms
     wfJerseyReporter.start();
 
     // Step 8 - Create WavefrontJvmReporter.Builder using applicationTags
-    WavefrontJvmReporter wfJvmReporter = new WavefrontJvmReporter.Builder(applicationTags).
-        withSource(wfReportingConfig.getSource()).build(wavefrontSender);
+    this.wfJvmReporter = new WavefrontJvmReporter.Builder(applicationTags).
+        withSource(source).build(wavefrontSender);
 
     // Step 9 - Start the JVM reporter to report JVM metrics
     wfJvmReporter.start();
 
-    // Step 10 - Return the filter that you should register with your Jersey based application.
-    return new Pair<>(wfJerseyFilterBuilder.build(), new ClientTracingFilter(tracer));
+    // Step 10 - Construct the filter that you should register with your Jersey based application.
+    this.wavefrontJerseyFilter = wfJerseyFilterBuilder.build();
+
+    this.wavefrontJaxrsClientFilter = new WavefrontJaxrsClientFilter(wavefrontSender,
+        applicationTags, source, tracer);
   }
 
+  public WavefrontJerseyFilter getWavefrontJerseyFilter() {
+    return wavefrontJerseyFilter;
+  }
+
+  public WavefrontJaxrsClientFilter getWavefrontJaxrsClientFilter() {
+    return wavefrontJaxrsClientFilter;
+  }
+
+  public ApplicationTags getApplicationTags() {
+    return applicationTags;
+  }
+
+  public String getSource() {
+    return source;
+  }
+
+  public Tracer getTracer() {
+    return tracer;
+  }
+
+  public WavefrontSender getWavefrontSender() {
+    return wavefrontSender;
+  }
+
+  public WavefrontJerseyReporter getWavefrontJerseyReporter() {
+    return wfJerseyReporter;
+  }
+
+  public WavefrontJvmReporter getWavefrontJvmReporter() {
+    return wfJvmReporter;
+  }
 }

--- a/src/main/java/com/wavefront/sdk/jersey/WavefrontJerseyFilter.java
+++ b/src/main/java/com/wavefront/sdk/jersey/WavefrontJerseyFilter.java
@@ -46,6 +46,9 @@ import static com.wavefront.sdk.common.Constants.SHARD_TAG_KEY;
 import static com.wavefront.sdk.common.Constants.WAVEFRONT_PROVIDED_SOURCE;
 import static com.wavefront.sdk.jersey.Constants.JERSEY_SERVER_COMPONENT;
 
+import static com.wavefront.sdk.jaxrs.Constants.PROPERTY_NAME;
+import static com.wavefront.sdk.jaxrs.Constants.WF_SPAN_HEADER;
+
 /**
  * A filter to generate Wavefront metrics and histograms for Jersey API requests/responses.
  *
@@ -58,7 +61,7 @@ public class WavefrontJerseyFilter implements ContainerRequestFilter, ContainerR
   private final ThreadLocal<Long> startTime = new ThreadLocal<>();
   private final ThreadLocal<Long> startTimeCpuNanos = new ThreadLocal<>();
   private final ConcurrentMap<MetricName, AtomicInteger> gauges = new ConcurrentHashMap<>();
-  private final String PROPERTY_NAME = "com.wavefront.sdk.jersey.internal.SpanWrapper.activeSpanWrapper";
+
   @Nullable
   private final Tracer tracer;
 
@@ -172,6 +175,10 @@ public class WavefrontJerseyFilter implements ContainerRequestFilter, ContainerR
         return;
       }
       String requestMetricKey = requestOptionalPair.get()._1;
+      if (tracer != null) {
+        String matchingPath = requestOptionalPair.get()._2;
+        containerResponseContext.getHeaders().add(WF_SPAN_HEADER, matchingPath);
+      }
       Optional<String> responseOptionalPair = MetricNameUtils.metricName(request,
           containerResponseContext);
       if (!responseOptionalPair.isPresent()) {


### PR DESCRIPTION
- Update the YamlReader class to return both the server-side filter and client-side filter at the same time.
- Add logic to inject `jersey.path` into headers to work with JAX-RS client side, see this PR: https://github.com/wavefrontHQ/wavefront-jaxrs-sdk-java/pull/3