### PR TITLE
Update Wavefront JAX-RS SDK to v1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-jersey-sdk-java</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Wavefront by VMware Jersey SDK for Java</name>
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-jaxrs-sdk-java</artifactId>
-            <version>1.1</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/src/test/java/com/wavefront/sdk/jersey/app/SampleApp.java
+++ b/src/test/java/com/wavefront/sdk/jersey/app/SampleApp.java
@@ -116,6 +116,11 @@ public class SampleApp extends Application<Configuration> {
       public void close() {
         // no-op
       }
+
+      @Override
+      public void flush() {
+        spanCache.clear();
+      }
     }, applicationTags).build()).build());
   }
 


### PR DESCRIPTION
- Update Wavefront JAX-RS SDK to `v1.2.0`
- Bump the version from `v1.1` to `v1.2.0`