### PR TITLE
Add guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 
     <properties>
         <java.version>1.8</java.version>
+        <guava.version>28.2-jre</guava.version>
     </properties>
 
     <build>
@@ -80,6 +81,11 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-jaxrs-sdk-java</artifactId>

--- a/src/main/java/com/wavefront/sdk/jersey/WavefrontJerseyFilter.java
+++ b/src/main/java/com/wavefront/sdk/jersey/WavefrontJerseyFilter.java
@@ -1,5 +1,7 @@
 package com.wavefront.sdk.jersey;
 
+import com.google.common.base.Preconditions;
+
 import com.wavefront.internal.reporter.SdkReporter;
 import com.wavefront.internal_reporter_java.io.dropwizard.metrics5.MetricName;
 import com.wavefront.sdk.common.Pair;
@@ -42,7 +44,6 @@ import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.tag.Tags;
-import jersey.repackaged.com.google.common.base.Preconditions;
 
 import static com.wavefront.sdk.common.Constants.CLUSTER_TAG_KEY;
 import static com.wavefront.sdk.common.Constants.NULL_TAG_VAL;

--- a/src/main/java/com/wavefront/sdk/jersey/reporter/WavefrontJerseyReporter.java
+++ b/src/main/java/com/wavefront/sdk/jersey/reporter/WavefrontJerseyReporter.java
@@ -1,5 +1,7 @@
 package com.wavefront.sdk.jersey.reporter;
 
+import com.google.common.base.Preconditions;
+
 import com.wavefront.internal.reporter.SdkReporter;
 import com.wavefront.internal.reporter.WavefrontInternalReporter;
 import com.wavefront.internal_reporter_java.io.dropwizard.metrics5.MetricName;
@@ -19,7 +21,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
 
-import jersey.repackaged.com.google.common.base.Preconditions;
 
 import static com.wavefront.sdk.common.Constants.APPLICATION_TAG_KEY;
 import static com.wavefront.sdk.common.Constants.SDK_METRIC_PREFIX;


### PR DESCRIPTION
From http://blog.dejavu.sk/2014/02/21/jersey-2-6-has-been-released-new-and-noteworthy/
> Jersey, from versions 2.6 for JAX-RS 2.0 and 1.18.1 for JAX-RS 1.1, no longer transitively brings Guava and ASM libraries to your application. This means that even when we still use them internally you can use different versions of these libraries. Classes from both of these libraries has been repackaged, jersey.repackaged.com.google.common and jersey.repackaged.objectweb.asm respectively, and shrinked to lower the footprint. ASM 5 is now part of jersey-server core module and for Guava we’ve created a separate bundle module jersey-guava as this dependency is widely used in multiple Jersey modules.

We need to add guava dependency to unblock using Jersey 2.6+